### PR TITLE
fix(viewOrders-component): enforce correct time formatting

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -33,7 +33,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {createdDate.toLocaleTimeString([], {hour12: false})}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
I just went ahead and used ISO:8601(hh:mm:ss) via toLocaleTimeString which seems to have fairly broad browser compatibility.  Would prob bring something like moment in for a typical project.